### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/leetcode_generate.py
+++ b/leetcode_generate.py
@@ -182,7 +182,7 @@ class Leetcode:
             data['lock'] = not json_data['is_paid'] and quiz['paid_only']
             data['difficulty'] = difficulty[quiz['difficulty']['level']]
             data['favorite'] = quiz['is_favor']
-            data['acceptance'] = "%.1f%%" % (float(quiz['stat']['total_acs']) * 100 / float(quiz['stat']['total_submitted']))
+            data['acceptance'] = "{0:.1f}%".format((float(quiz['stat']['total_acs']) * 100 / float(quiz['stat']['total_submitted'])))
             data['url'] = '{base}/problems/{title}'.format(base=self.base_url, title=quiz['stat']['question__title_slug'])
             data['pass'] = quiz['status']
             data['article'] = quiz['stat']['question__article__slug']


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:gangh:myleetcode?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:gangh:myleetcode?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)